### PR TITLE
used named routing- defined the routes and used ModalRoute to get args

### DIFF
--- a/lib/core/constant/constant.dart
+++ b/lib/core/constant/constant.dart
@@ -1,0 +1,5 @@
+class HeadLineConstant {
+  static const home = "/";
+  static const headline = "/headline";
+  static const web = "/web";
+}

--- a/lib/headline/pages/home_screen.dart
+++ b/lib/headline/pages/home_screen.dart
@@ -27,71 +27,69 @@ class _MyHomeScreenState extends State<MyHomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.black,
-          title: Text("NewsFeed"),
-        ),
-        body: Container(
-          decoration: BoxDecoration(color: Colors.black87),
-          child: Column(
-            children: [
-              Padding(
-                padding: EdgeInsets.all(10),
-                child: Center(
-                  heightFactor: 0.5,
-                  child: Text(
-                    "Top News",
-                    style: TextStyle(color: Colors.white),
-                    textAlign: TextAlign.center,
-                  ),
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        title: Text("NewsFeed"),
+      ),
+      body: Container(
+        decoration: BoxDecoration(color: Colors.black87),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.all(10),
+              child: Center(
+                heightFactor: 0.5,
+                child: Text(
+                  "Top News",
+                  style: TextStyle(color: Colors.white),
+                  textAlign: TextAlign.center,
                 ),
               ),
-              SizedBox(height: 10),
-              Expanded(
-                  child: RefreshIndicator(
-                onRefresh: () async {
-                  return _headlineBloc.eventSink
-                      .add(HeadLineActions.getHeadlines);
+            ),
+            SizedBox(height: 10),
+            Expanded(
+                child: RefreshIndicator(
+              onRefresh: () async {
+                return _headlineBloc.eventSink
+                    .add(HeadLineActions.getHeadlines);
+              },
+              child: StreamBuilder<List<HeadLineDomain>>(
+                initialData: List.empty(),
+                stream: _headlineBloc.headLineStream,
+                builder: (context, snapshot) {
+                  if (snapshot.hasError) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          "An error occured\nPlease hit the retry button",
+                          textAlign: TextAlign.center,
+                          style: TextStyle(color: Colors.white),
+                        ),
+                        TextButton(
+                          onPressed: () => _headlineBloc.eventSink
+                              .add(HeadLineActions.getHeadlines),
+                          child: Text("Retry"),
+                        ),
+                      ],
+                    );
+                  } else {
+                    return ListView.builder(
+                      physics: AlwaysScrollableScrollPhysics(),
+                      shrinkWrap: true,
+                      scrollDirection: Axis.vertical,
+                      itemCount:
+                          snapshot.data != null ? snapshot.data!.length : 0,
+                      itemBuilder: (context, index) =>
+                          HeadLineItem(model: snapshot.data![index]),
+                    );
+                  }
                 },
-                child: StreamBuilder<List<HeadLineDomain>>(
-                  initialData: List.empty(),
-                  stream: _headlineBloc.headLineStream,
-                  builder: (context, snapshot) {
-                    if (snapshot.hasError) {
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            "An error occured\nPlease hit the retry button",
-                            textAlign: TextAlign.center,
-                            style: TextStyle(color: Colors.white),
-                          ),
-                          TextButton(
-                            onPressed: () => _headlineBloc.eventSink
-                                .add(HeadLineActions.getHeadlines),
-                            child: Text("Retry"),
-                          ),
-                        ],
-                      );
-                    } else {
-                      return ListView.builder(
-                        physics: AlwaysScrollableScrollPhysics(),
-                        shrinkWrap: true,
-                        scrollDirection: Axis.vertical,
-                        itemCount:
-                            snapshot.data != null ? snapshot.data!.length : 0,
-                        itemBuilder: (context, index) =>
-                            HeadLineItem(model: snapshot.data![index]),
-                      );
-                    }
-                  },
-                ),
-              ))
-            ],
-          ),
+              ),
+            ))
+          ],
         ),
       ),
     );

--- a/lib/headline/pages/web_screen_with_push_name.dart
+++ b/lib/headline/pages/web_screen_with_push_name.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class WebPageWithPushNamed extends StatefulWidget {
+  const WebPageWithPushNamed({super.key});
+
+  @override
+  State<WebPageWithPushNamed> createState() => _WebPageWithPushNamedState();
+}
+
+class _WebPageWithPushNamedState extends State<WebPageWithPushNamed> {
+  @override
+  Widget build(BuildContext context) {
+    final WebPageModel model =
+        ModalRoute.of(context)!.settings.arguments as WebPageModel;
+    return Scaffold(
+      appBar: AppBar(title: Text(model.title)),
+      body: WebViewWidget(
+          controller: WebViewController()
+            ..setJavaScriptMode(JavaScriptMode.unrestricted)
+            ..setBackgroundColor(const Color(0x00000000))
+            ..setNavigationDelegate(
+              NavigationDelegate(
+                onProgress: (int progress) {
+                  // Update loading bar.
+                  Center(
+                      child: CircularProgressIndicator(
+                          value: progress.toDouble()));
+                },
+                onPageStarted: (String url) {},
+                onPageFinished: (String url) {},
+                onWebResourceError: (WebResourceError error) {},
+                onNavigationRequest: (NavigationRequest request) {
+                  if (request.url.startsWith('https://www.youtube.com/')) {
+                    return NavigationDecision.prevent;
+                  }
+                  return NavigationDecision.navigate;
+                },
+              ),
+            )
+            ..loadRequest(Uri.parse(model.url))),
+    );
+  }
+}
+
+class WebPageModel {
+  final String title;
+  final String url;
+  const WebPageModel({required this.title, required this.url});
+}

--- a/lib/headline/widget/head_line_tile.dart
+++ b/lib/headline/widget/head_line_tile.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:first_flutter_application/core/constant/constant.dart';
 import 'package:first_flutter_application/headline/model/head_line_domain.dart';
-import 'package:first_flutter_application/headline/pages/web_screen.dart';
+import 'package:first_flutter_application/headline/pages/web_screen_with_push_name.dart';
 import 'package:flutter/material.dart';
 
 class HeadLineItem extends StatelessWidget {
@@ -20,11 +21,12 @@ class HeadLineItem extends StatelessWidget {
     // return MaterialApp(
     //   home:
     return GestureDetector(
-      onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-              builder: (context) =>
-                  WebPage(webUrl: model.url!, title: model.title!))),
+      onTap: () => _goToWebPage(context, model.title!, model.url!),
+      // Navigator.push(
+      //     context,
+      //     MaterialPageRoute(
+      //         builder: (context) =>
+      //             WebPage(webUrl: model.url!, title: model.title!))),
       child: Container(
         decoration: BoxDecoration(
           image: DecorationImage(
@@ -71,5 +73,10 @@ class HeadLineItem extends StatelessWidget {
       ),
     );
     // );
+  }
+
+  _goToWebPage(BuildContext context, String title, String url) {
+    Navigator.pushNamed(context, HeadLineConstant.web,
+        arguments: WebPageModel(title: title, url: url));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:first_flutter_application/core/constant/constant.dart';
 import 'package:first_flutter_application/headline/pages/home_screen.dart';
+import 'package:first_flutter_application/headline/pages/web_screen_with_push_name.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -16,6 +18,10 @@ class MyApp extends StatelessWidget {
         brightness: Brightness.dark,
         useMaterial3: true,
       ),
+      initialRoute: HeadLineConstant.home,
+      routes: {
+        HeadLineConstant.web: (context) => WebPageWithPushNamed(),
+      },
       home: const MyHomeScreen(),
     );
   }


### PR DESCRIPTION
You can also use onGenerator to args
e.g:
At MaterialApp
```
MaterialApp{
         onGenerateRoute: (settings){
             if(settings.name == routeName){
                 final args = settings.argument as WebPageModel
                 return MaterialPageRoute(
                     builder: (context){
                        return WebPageWithOnGenerator(title: args.title, url: args.url)
                     }
                 )
             }
         }
}
```

Then your WebPageWithOnGenerator do not need to extract the arguments again
It will look like this:

```
class WebPageWithOnGenerator extends StatefulWidget{
   final String title;
   final String url;
   const WebPageWithOnGenerator({super.key, required this.title, required this.url});

   @override
   State<WebPageWithOnGenerator> createState => _WebPageWithOnGeneratorState();
}

class _WebPageWithOnGeneratorState extends State<WebPageWithOnGenerator>{
   //We can use the title and the url.
   ...
   ...
   ...
}
```